### PR TITLE
Remove broken CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Python port of the useful [ims-lti](https://github.com/instructure/ims-lti) Ruby
 
 ## Status
 
-[![Circle CI](https://circleci.com/gh/tophatmonocle/ims_lti_py/tree/develop.png?style=badge)](https://circleci.com/gh/tophatmonocle/ims_lti_py/tree/develop)
-
 The next version of this library is under development. Tests are failing and PRs are welcome!
 
 ## Installation


### PR DESCRIPTION
https://circleci.com/gh/tophatmonocle/ims_lti_py/tree/develop.png?style=badge is not available.